### PR TITLE
Local Model Creation and Serving via llama.cpp

### DIFF
--- a/MODEL_CREATION_AND_SERVING.md
+++ b/MODEL_CREATION_AND_SERVING.md
@@ -1,0 +1,147 @@
+# Model Conversion and Serving Guide
+
+This document outlines the steps to convert Hugging Face (HF) `safetensors` models to `gguf` format with image support and serve them using the `llama-server`. Note that two `gguf` files must be generated for proper operation:
+
+1. **Primary GGUF file** (standard model data)
+2. **MMProj GGUF file** (memory-mapped projection data)
+
+> **Important:** The conversion command must be run **twice**, once for each output file.
+
+---
+
+## Prerequisites
+
+- macOS (zsh)
+- Python 3.8+
+- `safetensors` and other HF dependencies installed
+- `llama.cpp` repository built with `llama-server` binary available
+
+Ensure you have the conversion script and server binary in your project:
+```bash
+# Example paths
+CONVERTER=~/proj/models/conversion/llama.cpp/convert_hf_to_gguf.py
+SERVER=~/proj/models/conversion/llama.cpp/build/bin/llama-server
+```
+
+---
+
+## 1. Model Conversion
+
+Replace the `INPUT_MODEL_DIR` and `OUT_DIR` below with your actual model paths.
+
+### 1.1 Generate Primary GGUF File
+
+```bash
+# Convert HF safetensors to primary gguf
+~ $CONVERTER \
+  ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct \
+  --outfile ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct-f16.gguf \
+  --outtype f16
+```
+
+### 1.2 Generate MMProj GGUF File
+
+```bash
+# Convert HF safetensors to memory-mapped projection gguf
+~ $CONVERTER \
+  ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct \
+  --outfile ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct--mmproj-f16.gguf \
+  --outtype f16 \
+  --mmproj
+```
+
+> You should now have two files in your output directory:
+> - `Qwen2.5-VL-7B-Instruct-f16.gguf`
+> - `Qwen2.5-VL-7B-Instruct--mmproj-f16.gguf`
+
+### 1.3 Conversion Script CLI Options
+
+Run the conversion script with `--help` to view all available flags and arguments:
+
+```bash
+python3 ./convert_hf_to_gguf.py --help
+```
+
+```text
+usage: convert_hf_to_gguf.py [-h] [--vocab-only] [--outfile OUTFILE] [--outtype {f32,f16,bf16,q8_0,tq1_0,tq2_0,auto}] [--bigendian] [--use-temp-file] [--no-lazy] [--model-name MODEL_NAME] [--verbose]
+                             [--split-max-tensors SPLIT_MAX_TENSORS] [--split-max-size SPLIT_MAX_SIZE] [--dry-run] [--no-tensor-first-split] [--metadata METADATA] [--print-supported-models] [--remote] [--mmproj]
+                             [model]
+```
+
+- `model` (positional): Path to the directory containing the Hugging Face model.
+- `-h`, `--help`: Show help message and exit.
+- `--vocab-only`: Extract only the vocabulary (no weights).
+- `--outfile OUTFILE`: Output file path; `{ftype}` in the default name is replaced by the `outtype`.
+- `--outtype {f32,f16,bf16,q8_0,tq1_0,tq2_0,auto}`: Output data type (float32, float16, bfloat16, Q8_0, ternary Q1/Q2, or auto-select 16-bit based on input).
+- `--bigendian`: Mark the output for big-endian execution environments.
+- `--use-temp-file`: Use temporary files during processing (helps avoid memory limits).
+- `--no-lazy`: Disable lazy evaluation; compute all tensors before writing.
+- `--model-name MODEL_NAME`: Override the embedded model name.
+- `--verbose`: Increase logging verbosity.
+- `--split-max-tensors SPLIT_MAX_TENSORS`: Maximum number of tensors per split when sharding.
+- `--split-max-size SPLIT_MAX_SIZE`: Maximum file size per split (e.g., `4G`, `500M`).
+- `--dry-run`: Print the planned splits without writing any files.
+- `--no-tensor-first-split`: Do not include tensors in the first split file.
+- `--metadata METADATA`: Path to an authorship metadata JSON override.
+- `--print-supported-models`: List all Hugging Face model IDs supported by the converter.
+- `--remote`: (Experimental) Stream safetensors from the Hugging Face Hub without full download; requires `HF_TOKEN` for gated repos.
+- `--mmproj`: (Experimental) Export a multimodal projection module; only for certain vision models (prefixes output with `mmproj-`).
+
+---
+
+## 2. Serving the Model
+
+Start the `llama-server` with both the primary and MMProj files:
+
+```bash
+~ $SERVER \
+  -m ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct-f16.gguf \
+  --mmproj ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct--mmproj-f16.gguf \
+  --ctx-size 30000 \
+  --jinja \
+  --host "0.0.0.0" \
+  --port 8090 \
+  --threads 8
+```
+
+- `--ctx-size`: Context window size (e.g., 30000 tokens)
+- `--jinja`: Enable Jinja template support
+- `--host` / `--port`: Binding interface and port
+- `--threads`: Number of worker threads
+
+---
+
+## 3. Tips & Troubleshooting
+
+- Verify that both `.gguf` files exist and have correct file names.
+- Check Python and HF dependencies if conversion fails.
+- Use `--verbose` on the conversion script for detailed logs.
+- Monitor `llama-server` logs for client connection and runtime errors.
+
+---
+
+## 4. Useful `llama-server` Options
+
+When starting the server, you can customize behavior with these commonly used flags:
+
+- `-h`, `--help`             : Print usage and exit.
+- `--version`                : Show version and build information.
+- `-t`, `--threads N`        : Number of worker threads for generation (default: auto / -1).
+- `-c`, `--ctx-size N`       : Context window size in tokens (default: loaded from model).
+- `-m`, `--model FILENAME`   : Path to the primary GGUF model file.
+- `--mmproj FILE`            : Path to the MMProj GGUF projection file.
+- `--jinja`                  : Enable Jinja template support for chat.
+- `--host HOST`              : Bind address or UNIX socket (default: `127.0.0.1`).
+- `--port PORT`              : Listening port (default: `8080`).
+- `--threads-http N`         : Number of threads for HTTP request handling (default: -1).
+- `--timeout N`              : Read/write timeout in seconds (default: `600`).
+- `--no-webui`               : Disable the built-in Web UI.
+- `--metrics`                : Enable Prometheus-compatible metrics endpoint.
+- `--slots`                  : Enable slots monitoring endpoint.
+- `--api-key KEY`            : Require this API key for authentication.
+- `--log-file FILENAME`      : Write server logs to the specified file.
+- `--verbose`, `--log-verbose`: Increase logging verbosity for debugging.
+
+---
+
+**End of Guide**

--- a/MODEL_CREATION_AND_SERVING.md
+++ b/MODEL_CREATION_AND_SERVING.md
@@ -18,9 +18,9 @@ This document outlines the steps to convert Hugging Face (HF) `safetensors` mode
 
 Ensure you have the conversion script and server binary in your project:
 ```bash
-# Example paths
-CONVERTER=~/proj/models/conversion/llama.cpp/convert_hf_to_gguf.py
-SERVER=~/proj/models/conversion/llama.cpp/build/bin/llama-server
+# Example paths (replace with your actual paths)
+CONVERTER=/path/to/convert_hf_to_gguf.py    # e.g., path to convert_hf_to_gguf.py script
+SERVER=/path/to/llama-server                # e.g., path to llama-server binary
 ```
 
 ---
@@ -33,9 +33,9 @@ Replace the `INPUT_MODEL_DIR` and `OUT_DIR` below with your actual model paths.
 
 ```bash
 # Convert HF safetensors to primary gguf
-~ $CONVERTER \
-  ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct \
-  --outfile ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct-f16.gguf \
+$CONVERTER \
+  /path/to/hf_model_dir \
+  --outfile /path/to/output/model-f16.gguf \
   --outtype f16
 ```
 
@@ -43,9 +43,9 @@ Replace the `INPUT_MODEL_DIR` and `OUT_DIR` below with your actual model paths.
 
 ```bash
 # Convert HF safetensors to memory-mapped projection gguf
-~ $CONVERTER \
-  ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct \
-  --outfile ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct--mmproj-f16.gguf \
+$CONVERTER \
+  /path/to/hf_model_dir \
+  --outfile /path/to/output/model-mmproj-f16.gguf \
   --outtype f16 \
   --mmproj
 ```
@@ -94,9 +94,9 @@ usage: convert_hf_to_gguf.py [-h] [--vocab-only] [--outfile OUTFILE] [--outtype 
 Start the `llama-server` with both the primary and MMProj files:
 
 ```bash
-~ $SERVER \
-  -m ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct-f16.gguf \
-  --mmproj ~/proj/models/Qwen/Qwen2.5-VL-7B-Instruct--mmproj-f16.gguf \
+$SERVER \
+  -m /path/to/output/model-f16.gguf \
+  --mmproj /path/to/output/model-mmproj-f16.gguf \
   --ctx-size 30000 \
   --jinja \
   --host "0.0.0.0" \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The script uses the `logging` module to output information about its execution. 
 ## Flow
 
 1.  **Load Environment Variables**: The script loads necessary environment variables, including the OpenAI API key, from a `.env` file.
-2.  **Initialize OpenAI Client**: An OpenAI client is created using the loaded API key.
+2.  **Initialize OpenAI Client**: An OpenAI client is created using the loaded API key.  If `LOCAL_API_BASE` is set, the client will instead connect to the specified local endpoint using `api_key=None`.
 3.  **Image Processing**:
     *   The script takes an image file path as input.
     *   It determines the MIME type of the image.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ python image_analyzer.py
 ## Example
 
 The script includes a test image located at `data/test_images/data_table.png`.
+
+## Model Conversion and Serving
+
+For instructions on converting HF `safetensors` models to `gguf` (primary and MMProj) and serving with `llama-server`, see [MODEL_CREATION_AND_SERVING.md](MODEL_CREATION_AND_SERVING.md).

--- a/image_analyzer.py
+++ b/image_analyzer.py
@@ -11,17 +11,20 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 # 1. Load environment variables from .env file
 load_dotenv()
 
-# 2. Create OpenAI client
-# The client will automatically pick up OPENAI_API_KEY and OPENAI_API_BASE 
-# from environment variables if they are set by load_dotenv().
+# 2. Create OpenAI client (use local API if specified)
+local_api_base = os.getenv('LOCAL_API_BASE')
 try:
-    client = OpenAI()
-    # Check if the API key was loaded
-    if not client.api_key:
-        raise ValueError("OPENAI_API_KEY not found or is empty. Make sure it's set in your .env file or environment variables.")
+    if local_api_base:
+        logging.info(f"Using local OpenAI API base: {local_api_base}")
+        client = OpenAI(api_key="None", base_url=local_api_base)
+    else:
+        client = OpenAI()
+        # Check if the API key was loaded when not using local API
+        if not client.api_key:
+            raise ValueError("OPENAI_API_KEY not found or is empty. Make sure it's set in your .env file or environment variables.")
 except Exception as e:
-    logging.error(f"Error initializing OpenAI client: {e}") # Replaced print
-    client = None # Ensure client is None if initialization fails
+    logging.error(f"Error initializing OpenAI client: {e}")
+    client = None  # Ensure client is None if initialization fails
 
 def get_image_mime_type(image_path):
     """Guesses the MIME type of an image file."""


### PR DESCRIPTION
This pull request introduces a comprehensive guide for converting Hugging Face models to `gguf` format and serving them with `llama-server`, along with updates to the OpenAI client initialization process to support a local API base. The changes include documentation updates, code modifications, and improved error handling.

### Documentation Updates
* [`MODEL_CREATION_AND_SERVING.md`](diffhunk://#diff-e5dc85f4e2a83db32361a7ae29ef6212d6f68803fe23889989cbeaffaac50397R1-R147): Added a detailed guide for converting Hugging Face `safetensors` models to `gguf` format (primary and MMProj) and serving them using `llama-server`. The guide includes prerequisites, step-by-step instructions, CLI options for the conversion script, server configuration, troubleshooting tips, and commonly used server flags.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38): Updated the OpenAI client initialization section to mention support for a local API base. Added a reference to the new model conversion and serving guide. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R82)

### Code Updates
* [`image_analyzer.py`](diffhunk://#diff-ae39043384c4ef4d92cd3155a971039bbb610720ee6c3e5dff4197faac69726aL14-R26): Modified the OpenAI client initialization to check for a `LOCAL_API_BASE` environment variable. If set, the client connects to the specified local endpoint with `api_key=None`. Added logging to indicate whether a local or default API base is being used and improved error handling for client initialization.